### PR TITLE
PYD-674 | Add colorBackground var to render options type

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -11,6 +11,7 @@ export interface GuestyTokenizationStyles {
   colorBorderError?: string;
   colorBorderHover?: string;
   colorPlaceholder?: string;
+  colorBackground?: string;
   colorFormBackground?: string;
   colorBackgroundError?: string;
   colorBackgroundDisabled?: string;


### PR DESCRIPTION
### TL&DR;

Added `colorBackground` style variable to render options type

### PR checklist

- [ ] Unit tests covering new logic
- [ ] No tests/Linter/snapshots issues
- [x] Aligned with `master`
