### PR TITLE
PFE-328 | Update LICENSE.md copyright year to 2026

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2023 Guesty Inc.
+Copyright (c) 2026 Guesty Inc.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to use the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 


### PR DESCRIPTION
## Summary

- Updated copyright year from 2023 to 2026 in `LICENSE.md`, as requested by the Legal team.